### PR TITLE
Addition of Safe Death Mod support

### DIFF
--- a/Patches/TombstonePatcher.cs
+++ b/Patches/TombstonePatcher.cs
@@ -19,6 +19,10 @@ namespace ComfyQuickSlots {
     [HarmonyPrefix]
     [HarmonyPatch(nameof(Player.CreateTombStone))]
     public static void CreateTombStonePrefix(Player __instance) {
+      // Safe Death Mod Support
+      if (SafeDeathSupport.Value) {
+        return;
+      }
       // Log Items in tombstone on death for auditing and tracking purposes
       Directory.CreateDirectory(LogFilesPath.Value);
       string filename = __instance.GetPlayerID() + ".csv";

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -42,7 +42,7 @@ namespace ComfyQuickSlots {
             LogFilesPath = config.Bind("Logging", "logFilesPath", "ItemsOnDeath/", "Path to where logging of items on death are saved.");
 
             // Mod Support
-            SafeDeathSupport = config.Bind("_Global", "SafeDeathSupport", false, "Enable or disable support for the 'Safe Death' mod to prevent quickslot item removal.");
+            SafeDeathSupport = config.Bind("_Global", "SafeDeathSupport", false, "Enable or disable support for the 'Safe Death' mod. Will ignore ComfyQuickSlots Tombstone behaviour to prevent quickslot item removal.");
         }
     }
 

--- a/PluginConfig.cs
+++ b/PluginConfig.cs
@@ -23,6 +23,8 @@ namespace ComfyQuickSlots {
         // Logging
         public static ConfigEntry<string> LogFilesPath = default!;
 
+        // Mod Support
+        public static ConfigEntry<bool> SafeDeathSupport = default!;
 
         public static void BindConfig(ConfigFile config) {
             IsModEnabled = config.Bind("_Global", "isModEnabled", true, "Globally enable or disable this mod.");
@@ -38,6 +40,9 @@ namespace ComfyQuickSlots {
 
             // Logging
             LogFilesPath = config.Bind("Logging", "logFilesPath", "ItemsOnDeath/", "Path to where logging of items on death are saved.");
+
+            // Mod Support
+            SafeDeathSupport = config.Bind("_Global", "SafeDeathSupport", false, "Enable or disable support for the 'Safe Death' mod to prevent quickslot item removal.");
         }
     }
 


### PR DESCRIPTION
Hi,

This is a very simple return statement added within the Tombstone Function, using a bool in config, to disable the Tombstone behavior, to allow SafeDeath (fellow Thunderstore mod) to have exclusive control over the death event function.

Thank you for providing this mod and for allowing edits

Please let me know,
Thanks SnowyTheVampire